### PR TITLE
Use cached graph from nsls-ii-forge/auto-tick-graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,11 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# bot related files
+node_attrs/*
+status/*
+versions/*
+dask-worker-space/*
+graph.json
+auto-tick-graph/*

--- a/scripts/auto_tick.sh
+++ b/scripts/auto_tick.sh
@@ -43,7 +43,12 @@ time graph-utils make -o nsls-ii-forge -c -f names.txt -m 10
 time graph-utils update
 # push changes to graph repo
 git add .
-git commit -m "Update graph from auto-tick-bot [$(BUILD_BUILDNUMBER)]"
+if [ ! -z "$BUILD_BUILDNUMBER" ]; then
+    commit_msg="Update graph from auto-tick-bot [${BUILD_BUILDNUMBER}]"
+else
+    commit_msg="Update graph from auto-tick-bot [local $(hostname)]"
+fi
+git commit -m $commit_msg
 git push origin master
 # move out of auto-tick-graph
 cd ..

--- a/scripts/auto_tick.sh
+++ b/scripts/auto_tick.sh
@@ -29,21 +29,35 @@ set -e
 source ~/mc/etc/profile.d/conda.sh
 conda env list
 conda activate botenv
+# clone graph repo to get cached graph
+git clone --depth 1 https://github.com/nsls-ii-forge/auto-tick-graph.git
+cp names.txt ./auto-tick-graph/names.txt
+cd ./auto-tick-graph/
 # list of packages to be updated (in graph)
 echo "=================="
 cat names.txt
 echo "=================="
-# clean current directory of bot files
-auto-tick clean -y
 # create graph with node_attrs/* and graph.json
 time graph-utils make -o nsls-ii-forge -c -f names.txt -m 10
 # update graph with new versions from their sources (see versions/*)
 time graph-utils update
+# push changes to graph repo
+git add .
+git commit -m "Update graph (auto-tick-bot)"
+git push origin master
+# move out of auto-tick-graph
+cd ..
+# copy graph files
+cp ./auto-tick-graph/graph.json ./ -v
+cp -r ./auto-tick-graph/node_attrs ./ -v
+cp -r ./auto-tick-graph/versions ./ -v
 # dry run of migrations to catch errors before PRs
 auto-tick run --dry-run
 # full run of migrations and submit PRs (see pr_json/*)
-time auto-tick run --fork
+time auto-tick run
 # output status of migrations to status/*
 auto-tick status
+cat ./status/could_use_help.json
+cat ./status/version_status.json
 # cleanup
 auto-tick clean -y

--- a/scripts/auto_tick.sh
+++ b/scripts/auto_tick.sh
@@ -43,7 +43,7 @@ time graph-utils make -o nsls-ii-forge -c -f names.txt -m 10
 time graph-utils update
 # push changes to graph repo
 git add .
-git commit -m "Update graph (auto-tick-bot)"
+git commit -m "Update graph from auto-tick-bot [$(BUILD_BUILDNUMBER)]"
 git push origin master
 # move out of auto-tick-graph
 cd ..

--- a/scripts/auto_tick.sh
+++ b/scripts/auto_tick.sh
@@ -31,7 +31,7 @@ conda env list
 conda activate botenv
 # clone graph repo to get cached graph
 git clone --depth 1 https://github.com/nsls-ii-forge/auto-tick-graph.git
-cp names.txt ./auto-tick-graph/names.txt
+cp names.txt ./auto-tick-graph/
 cd ./auto-tick-graph/
 # list of packages to be updated (in graph)
 echo "=================="
@@ -60,4 +60,5 @@ auto-tick status
 cat ./status/could_use_help.json
 cat ./status/version_status.json
 # cleanup
+rm -rfv ./auto-tick-graph
 auto-tick clean -y


### PR DESCRIPTION
- Clones the repo from https://github.com/nsls-ii-forge/auto-tick-graph.git with depth 1.
- Overwrites their `names.txt` with our `names.txt`
- Updates the `graph.json` and `node_attrs/*`
- Updates the `versions/*`
- Adds, commits, and pushes the changes to auto-tick-graph master branch
- Copies updated files for bot to run outside of graph repo
- Runs the bot
- Reports status
- Cleans up files

I tested this approach locally. Not sure if the build will fail if there is nothing to commit.

Closes #2 